### PR TITLE
Add toleration for `node-role.kubernetes.io/control-plane:NoSchedule`

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -86,9 +86,15 @@ local ccm = [
         template+: {
           spec+: {
             nodeSelector: params.nodeSelector,
-            tolerations+: [ {
-              key: 'node.kubernetes.io/not-ready',
-            } ],
+            tolerations+: [
+              {
+                key: 'node.kubernetes.io/not-ready',
+              },
+              {
+                key: 'node-role.kubernetes.io/control-plane',
+                effect: 'NoSchedule',
+              },
+            ],
             containers: [
               super.containers[0] {
                 image:

--- a/tests/golden/defaults/exoscale-cloud-controller-manager/exoscale-cloud-controller-manager/manager/20_ccm_deployment_syn_exoscale_cloud_controller_manager_exoscale_cloud_controller_manager.yaml
+++ b/tests/golden/defaults/exoscale-cloud-controller-manager/exoscale-cloud-controller-manager/manager/20_ccm_deployment_syn_exoscale_cloud_controller_manager_exoscale_cloud_controller_manager.yaml
@@ -52,3 +52,5 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
         - key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane

--- a/tests/golden/openshift/exoscale-cloud-controller-manager/exoscale-cloud-controller-manager/manager/20_ccm_deployment_syn_exoscale_cloud_controller_manager_exoscale_cloud_controller_manager.yaml
+++ b/tests/golden/openshift/exoscale-cloud-controller-manager/exoscale-cloud-controller-manager/manager/20_ccm_deployment_syn_exoscale_cloud_controller_manager_exoscale_cloud_controller_manager.yaml
@@ -52,3 +52,5 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
         - key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
I ran into an issue where the CCM Pod got stuck in Pending phase because it didn't tolerate the taint `node-role.kubernetes.io/control-plane:NoSchedule`. 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
